### PR TITLE
patch(rename branches to branch): refactored the command "branches" to "branch", fixed misspelling of create tag in gitio.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ BetterGit is a lightweight command-line companion for Git. It streamlines daily 
 
 - Message generation via `bg suggest` (interactive) and `bg commit` (one-shot).
 - Staging shortcuts: `bg add` for everything or selected paths.
-- Branch utilities: `bg branches`, `bg branch-info`, `bg switch`, `bg create-branch`, `bg delete-branch`.
+- Branch utilities: `bg branch`, `bg branch-info`, `bg switch`, `bg create-branch`, `bg delete-branch`.
 - Tag utilities: `bg tag` to review tags, `bg create-tag` to add new ones and optionally push them, `bg delete-tag` to clean up locally or prompt for remote removal, and `bg delete-remote-tag` for one-shot remote cleanup.
 - Simple pushes: `bg push` for the current branch, `bg push-to` for any branch without switching.
 - Interactive branch deletion that asks whether to drop the remote copy as well.

--- a/docs/RELEASE_NOTES.md
+++ b/docs/RELEASE_NOTES.md
@@ -1,5 +1,9 @@
 # BetterGit Release Notes
 
+## v2.1.2 (2025-10-02)
+- `bg branches` is now `bg branch`.
+- Fixed misspelling of `create-tag` in `bettergit.core.gitio`.
+
 ## v2.1.1 (2025-10-02)
 - `bg create-tag` now asks whether to push the new tag to the selected remote (defaults to `origin`).
 - `bg delete-tag` detects matching remote tags, offers to delete them, and respects `--remote/-r`.

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -14,7 +14,7 @@ BetterGit (`bg`) is a productivity layer on top of Git. It keeps everyday tasks 
   - [`bg add`](#bg-add)
   - [`bg suggest`](#bg-suggest)
   - [`bg commit`](#bg-commit)
-  - [`bg branches`](#bg-branches)
+  - [`bg branch`](#bg-branch)
   - [`bg branch-info`](#bg-branch-info)
   - [`bg switch`](#bg-switch)
   - [`bg create-branch`](#bg-create-branch)
@@ -106,7 +106,7 @@ BetterGit can ask an LLM to draft commit messages. By default we talk to [Ollama
 | `bg add`           | Stage everything or specific paths                       | `--config/-c` |
 | `bg suggest`       | Interactive Conventional Commit recommendation           | `--llm/--no-llm`, `--config/-c` |
 | `bg commit`        | One-shot commit using the generated message              | `--llm/--no-llm`, `--config/-c` |
-| `bg branches`      | List branches (add remotes with `--all/-a`)              | `--all/-a`, `--config/-c` |
+| `bg branch`        | List branches (add remotes with `--all/-a`)              | `--all/-a`, `--config/-c` |
 | `bg branch-info`   | Show tracking target, ahead/behind, last commit summary  | `--branch/-b`, `--config/-c` |
 | `bg switch`        | Check out another branch                                 | `--config/-c` |
 | `bg create-branch` | Create a branch, optionally switch/overwrite             | `--from/-f`, `--no-switch`, `--force/-F`, `--config/-c` |
@@ -134,7 +134,7 @@ The `--llm` / `--no-llm` toggles override the default model usage for the curren
 ### `bg commit`
 Skips the interactive step and commits immediately after the message is generated. Ideal for automation or when you already trust the suggestion.
 
-### `bg branches`
+### `bg branch`
 Groups branches by category, marking the current one with `*` and highlighting local standalone branches, remote branches, remote HEAD pointers, and branches created via `bg create-branch --from`; derived branches also show their parent. Include `--all/-a` to show remote branches.
 
 ### `bg branch-info`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "bettergit"
-version = "2.1.1"
+version = "2.1.2"
 description = "BetterGit is a conversational CLI wrapper for Git that encourages Conventional Commits."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/src/bettergit/__init__.py
+++ b/src/bettergit/__init__.py
@@ -1,4 +1,4 @@
 ﻿__all__ = ['__version__']
 
-__version__ = '2.1.1'
+__version__ = '2.1.2'
 

--- a/src/bettergit/cli/commands/branch.py
+++ b/src/bettergit/cli/commands/branch.py
@@ -24,10 +24,10 @@ def _category_header(title: str, note: str | None) -> str:
 
 
 def register(app: typer.Typer) -> None:
-    """Register the `bg branches` command."""
+    """Register the `bg branch` command."""
 
-    @app.command("branches", help="Show a grouped, color-coded list of branches.")
-    def branches(
+    @app.command("branch", help="Show a grouped, color-coded list of branches.")
+    def branch(
         all_: bool = typer.Option(False, "--all", "-a", help="Include remote branches."),
         config_path: str | None = typer.Option(None, "--config", "-c", help="Path to a configuration file."),
     ) -> None:
@@ -36,10 +36,10 @@ def register(app: typer.Typer) -> None:
             current = gitio.current_branch()
             items = gitio.list_branches(all_=all_)
         except GitError as exc:
-            show_error("branches", message=str(exc))
+            show_error("branch", message=str(exc))
             raise typer.Exit(code=1)
 
-        show_success("branches", "list")
+        show_success("branch", "list")
         origins = branchmeta.load_all()
 
         current_lines: list[str] = []

--- a/src/bettergit/cli/main.py
+++ b/src/bettergit/cli/main.py
@@ -8,7 +8,7 @@ from typer.core import TyperGroup
 from bettergit import __version__
 from bettergit.cli.commands.add import register as register_add
 from bettergit.cli.commands.branch_info import register as register_branch_info
-from bettergit.cli.commands.branches import register as register_branches
+from bettergit.cli.commands.branch import register as register_branch
 from bettergit.cli.commands.commit import register as register_commit
 from bettergit.cli.commands.create_branch import register as register_create_branch
 from bettergit.cli.commands.delete_branch import register as register_delete_branch
@@ -47,7 +47,7 @@ HELP_TEXT = textwrap.dedent(
 
     ----------------------------------------------------------------------
     Branch Management
-      bg branches       Grouped, color-coded view for current, standalone, derived, and remote branches (add --all/-a for remotes).
+      bg branch         Grouped, color-coded view for current, standalone, derived, and remote branches (add --all/-a for remotes).
       bg branch-info    Ahead/behind stats, tracking target, last commit snapshot.
       bg switch         Checkout another branch.
       bg create-branch  Start from HEAD by default; can switch automatically.
@@ -134,7 +134,7 @@ def main(
 register_add(app)
 register_suggest(app)
 register_commit(app)
-register_branches(app)
+register_branch(app)
 register_switch(app)
 register_branch_info(app)
 register_push(app)

--- a/src/bettergit/core/gitio.py
+++ b/src/bettergit/core/gitio.py
@@ -23,7 +23,7 @@ __all__ = [
     "push",
     "remote_branch_exists",
     "tag",
-    "crete_tag",
+    "create_tag",
     "delete_tag",
 ]
 


### PR DESCRIPTION
first commit by Elya_Cherry #iwashere